### PR TITLE
fix same picture error in index

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -44,7 +44,7 @@ count = 0
     )
   bike.picture.attach(io: file, filename: "file.png", content_type: "image/png")
   bike.save
-  count =+ 1
+  count += 1
   puts "Creating #{bike.name}"
 end
 


### PR DESCRIPTION
Fixed the error that makes all seeded bikes in the index have the same picture. 